### PR TITLE
Initial support for Hazelcast repositories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/
+
+# Eclipse
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.springframework.data</groupId>
+	<artifactId>spring-data-hazelcast</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+
+	<name>Spring Data Hazelcast</name>
+
+	<parent>
+		<groupId>org.springframework.data.build</groupId>
+		<artifactId>spring-data-parent</artifactId>
+		<version>1.6.0.BUILD-SNAPSHOT</version>
+		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
+	</parent>
+
+	<properties>
+		<dist.key>DATAHC</dist.key>
+		<hazelcast>3.3</hazelcast>
+		<springdata.commons>1.10.0.BUILD-SNAPSHOT</springdata.commons>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>${springdata.commons}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-tx</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast</artifactId>
+			<version>${hazelcast}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.mysema.querydsl</groupId>
+			<artifactId>querydsl-core</artifactId>
+			<version>${querydsl}</version>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.3.1</version>
+				<executions>
+					<execution>
+						<id>enforce-rules</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<rules>
+						<requireJavaVersion>
+							<version>[1.8,1.9)</version>
+						</requireJavaVersion>
+					</rules>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>wagon-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+			</plugin>
+
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-libs-snapshot</id>
+			<url>http://repo.spring.io/libs-snapshot</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-plugins-release</id>
+			<url>http://repo.spring.io/plugins-release</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,15 +19,15 @@
 	<properties>
 		<dist.key>DATAHC</dist.key>
 		<hazelcast>3.3</hazelcast>
-		<springdata.commons>1.10.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.keyvalue>0.1.0.BUILD-SNAPSHOT</springdata.keyvalue>
 	</properties>
 
 	<dependencies>
 
 		<dependency>
 			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-commons</artifactId>
-			<version>${springdata.commons}</version>
+			<artifactId>spring-data-keyvalue</artifactId>
+			<version>${springdata.keyvalue}</version>
 		</dependency>
 		
 		<dependency>

--- a/src/main/java/org/springframework/data/hazelcast/HazelcastKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/hazelcast/HazelcastKeyValueAdapter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import org.springframework.data.hazelcast.HazelcastQueryEngine;
+import org.springframework.data.keyvalue.core.AbstractKeyValueAdapter;
+import org.springframework.util.Assert;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+
+/**
+ * @author Christoph Strobl
+ */
+public class HazelcastKeyValueAdapter extends AbstractKeyValueAdapter {
+
+	private HazelcastInstance hzInstance;
+
+	public HazelcastKeyValueAdapter() {
+		this(Hazelcast.newHazelcastInstance());
+	}
+
+	public HazelcastKeyValueAdapter(HazelcastInstance hzInstance) {
+
+		super(new HazelcastQueryEngine());
+		Assert.notNull(hzInstance, "hzInstance must not be 'null'.");
+		this.hzInstance = hzInstance;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Object put(Serializable id, Object item, Serializable keyspace) {
+
+		Assert.notNull(id, "Id must not be 'null' for adding.");
+		Assert.notNull(item, "Item must not be 'null' for adding.");
+
+		return getMap(keyspace).put(id, item);
+	}
+
+	@Override
+	public boolean contains(Serializable id, Serializable keyspace) {
+		return getMap(keyspace).containsKey(id);
+	}
+
+	@Override
+	public Object get(Serializable id, Serializable keyspace) {
+		return getMap(keyspace).get(id);
+	}
+
+	@Override
+	public Object delete(Serializable id, Serializable keyspace) {
+		return getMap(keyspace).remove(id);
+	}
+
+	@Override
+	public Collection<?> getAllOf(Serializable keyspace) {
+		return getMap(keyspace).values();
+	}
+
+	@Override
+	public void deleteAllOf(Serializable keyspace) {
+		getMap(keyspace).clear();
+	}
+
+	@Override
+	public void clear() {
+		// TODO: remove all elements
+	}
+
+	@SuppressWarnings("rawtypes")
+	protected IMap getMap(final Serializable keyspace) {
+
+		Assert.isInstanceOf(String.class, keyspace, "Keyspace identifier must of of type String.");
+		return hzInstance.getMap((String) keyspace);
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		hzInstance.shutdown();
+	}
+
+}

--- a/src/main/java/org/springframework/data/hazelcast/HazelcastQueryEngine.java
+++ b/src/main/java/org/springframework/data/hazelcast/HazelcastQueryEngine.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Map.Entry;
+
+import org.springframework.data.hazelcast.HazelcastKeyValueAdapter;
+import org.springframework.data.keyvalue.core.CriteriaAccessor;
+import org.springframework.data.keyvalue.core.QueryEngine;
+import org.springframework.data.keyvalue.core.SortAccessor;
+import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+
+import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+
+/**
+ * @author Christoph Strobl
+ */
+public class HazelcastQueryEngine extends QueryEngine<HazelcastKeyValueAdapter, Predicate<?, ?>, Comparator<Entry>> {
+
+	public HazelcastQueryEngine() {
+		super(HazelcastCriteriaAccessor.INSTANCE, HazelcastSortAccessor.INSTANCE);
+	}
+
+	@Override
+	public Collection<?> execute(Predicate<?, ?> criteria, Comparator<Entry> sort, int offset, int rows,
+			Serializable keyspace) {
+
+		Predicate<?, ?> predicateToUse = criteria;
+
+		if (sort != null || offset > 0 || rows > 0) {
+			PagingPredicate pp = new PagingPredicate(criteria, (Comparator<Entry>) sort, rows);
+			if (offset > 0 && rows > 0) {
+				int x = offset / rows;
+				while (x > 0) {
+					pp.nextPage();
+					x--;
+				}
+			}
+			predicateToUse = pp;
+		}
+
+		return this.getAdapter().getMap(keyspace).values(predicateToUse);
+
+	}
+
+	@Override
+	public long count(Predicate<?, ?> criteria, Serializable keyspace) {
+		return this.getAdapter().getMap(keyspace).keySet(criteria).size();
+	}
+
+	static enum HazelcastCriteriaAccessor implements CriteriaAccessor<Predicate<?, ?>> {
+		INSTANCE;
+
+		@Override
+		public Predicate<?, ?> resolve(KeyValueQuery<?> query) {
+
+			if (query == null || query.getCritieria() == null) {
+				return null;
+			}
+
+			if (query.getCritieria() instanceof Predicate) {
+				return (Predicate<?, ?>) query.getCritieria();
+			}
+
+			if (query.getCritieria() instanceof PredicateBuilder) {
+				return (PredicateBuilder) query.getCritieria();
+			}
+
+			throw new UnsupportedOperationException();
+		}
+
+	}
+
+	static enum HazelcastSortAccessor implements SortAccessor<Comparator<Entry>> {
+
+		INSTANCE;
+
+		@Override
+		public Comparator<Entry> resolve(KeyValueQuery<?> query) {
+
+			if (query == null || query.getSort() == null) {
+				return null;
+			}
+
+			// TODO: create serializable sorter;
+			throw new UnsupportedOperationException();
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/hazelcast/repository/config/EnableHazelcastRepositories.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/config/EnableHazelcastRepositories.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast.repository.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.hazelcast.repository.query.HazelcastQueryCreator;
+import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.keyvalue.repository.config.QueryCreatorType;
+import org.springframework.data.keyvalue.repository.support.KeyValueRepositoryFactoryBean;
+import org.springframework.data.repository.query.QueryLookupStrategy;
+import org.springframework.data.repository.query.QueryLookupStrategy.Key;
+
+/**
+ * Annotation to activate Hazelcast repositories. If no base package is configured through either {@link #value()},
+ * {@link #basePackages()} or {@link #basePackageClasses()} it will trigger scanning of the package of annotated class.
+ * 
+ * @author Christoph Strobl
+ * @author Oliver Gierke
+ */
+@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Import(HazelcastRepositoriesRegistrar.class)
+@QueryCreatorType(HazelcastQueryCreator.class)
+public @interface EnableHazelcastRepositories {
+
+	/**
+	 * Alias for the {@link #basePackages()} attribute. Allows for more concise annotation declarations e.g.:
+	 * {@code @EnableJpaRepositories("org.my.pkg")} instead of {@code @EnableJpaRepositories(basePackages="org.my.pkg")}.
+	 */
+	String[] value() default {};
+
+	/**
+	 * Base packages to scan for annotated components. {@link #value()} is an alias for (and mutually exclusive with) this
+	 * attribute. Use {@link #basePackageClasses()} for a type-safe alternative to String-based package names.
+	 */
+	String[] basePackages() default {};
+
+	/**
+	 * Type-safe alternative to {@link #basePackages()} for specifying the packages to scan for annotated components. The
+	 * package of each class specified will be scanned. Consider creating a special no-op marker class or interface in
+	 * each package that serves no purpose other than being referenced by this attribute.
+	 */
+	Class<?>[] basePackageClasses() default {};
+
+	/**
+	 * Specifies which types are not eligible for component scanning.
+	 */
+	Filter[] excludeFilters() default {};
+
+	/**
+	 * Specifies which types are eligible for component scanning. Further narrows the set of candidate components from
+	 * everything in {@link #basePackages()} to everything in the base packages that matches the given filter or filters.
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * Returns the postfix to be used when looking up custom repository implementations. Defaults to {@literal Impl}. So
+	 * for a repository named {@code PersonRepository} the corresponding implementation class will be looked up scanning
+	 * for {@code PersonRepositoryImpl}.
+	 * 
+	 * @return
+	 */
+	String repositoryImplementationPostfix() default "Impl";
+
+	/**
+	 * Configures the location of where to find the Spring Data named queries properties file.
+	 * 
+	 * @return
+	 */
+	String namedQueriesLocation() default "";
+
+	/**
+	 * Returns the key of the {@link QueryLookupStrategy} to be used for lookup queries for query methods. Defaults to
+	 * {@link Key#CREATE_IF_NOT_FOUND}.
+	 * 
+	 * @return
+	 */
+	Key queryLookupStrategy() default Key.CREATE_IF_NOT_FOUND;
+
+	/**
+	 * Returns the {@link FactoryBean} class to be used for each repository instance. Defaults to
+	 * {@link KeyValueRepositoryFactoryBean}.
+	 * 
+	 * @return
+	 */
+	Class<?> repositoryFactoryBeanClass() default KeyValueRepositoryFactoryBean.class;
+
+	/**
+	 * Configures the name of the {@link KeyValueOperations} bean to be used with the repositories detected.
+	 * 
+	 * @return
+	 */
+	String keyValueTemplateRef() default "keyValueTemplate";
+
+	/**
+	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the
+	 * repositories infrastructure.
+	 */
+	boolean considerNestedRepositories() default false;
+}

--- a/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoriesRegistrar.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast.repository.config;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.data.keyvalue.repository.config.KeyValueRepositoriesRegistrar;
+
+/**
+ * Special {@link KeyValueRepositoriesRegistrar} to point the infrastructure to inspect
+ * {@link EnableHazelcastRepositories}.
+ * 
+ * @author Oliver Gierke
+ */
+class HazelcastRepositoriesRegistrar extends KeyValueRepositoriesRegistrar {
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoriesRegistrar#getAnnotation()
+	 */
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableHazelcastRepositories.class;
+	}
+}

--- a/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoriesRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@ package org.springframework.data.hazelcast.repository.config;
 
 import java.lang.annotation.Annotation;
 
-import org.springframework.data.keyvalue.repository.config.KeyValueRepositoriesRegistrar;
+import org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension;
+import org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 
 /**
  * Special {@link KeyValueRepositoriesRegistrar} to point the infrastructure to inspect
@@ -25,7 +27,7 @@ import org.springframework.data.keyvalue.repository.config.KeyValueRepositoriesR
  * 
  * @author Oliver Gierke
  */
-class HazelcastRepositoriesRegistrar extends KeyValueRepositoriesRegistrar {
+class HazelcastRepositoriesRegistrar extends RepositoryBeanDefinitionRegistrarSupport {
 
 	/* 
 	 * (non-Javadoc)
@@ -34,5 +36,49 @@ class HazelcastRepositoriesRegistrar extends KeyValueRepositoriesRegistrar {
 	@Override
 	protected Class<? extends Annotation> getAnnotation() {
 		return EnableHazelcastRepositories.class;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport#getExtension()
+	 */
+	@Override
+	protected RepositoryConfigurationExtension getExtension() {
+		return new HazelcastRepositoryConfigurationExtension();
+	}
+
+	/**
+	 * Hazelcast-specific {@link RepositoryConfigurationExtension}.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private static class HazelcastRepositoryConfigurationExtension extends KeyValueRepositoryConfigurationExtension {
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension#getModuleName()
+		 */
+		@Override
+		public String getModuleName() {
+			return "Hazelcast";
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension#getModulePrefix()
+		 */
+		@Override
+		protected String getModulePrefix() {
+			return "hazelcast";
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension#getDefaultKeyValueTemplateRef()
+		 */
+		@Override
+		protected String getDefaultKeyValueTemplateRef() {
+			return "hazelcastKeyValueTemplate";
+		}
 	}
 }

--- a/src/main/java/org/springframework/data/hazelcast/repository/query/HazelcastQueryCreator.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/query/HazelcastQueryCreator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast.repository.query;
+
+import java.util.Iterator;
+
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+import org.springframework.data.repository.query.ParameterAccessor;
+import org.springframework.data.repository.query.parser.AbstractQueryCreator;
+import org.springframework.data.repository.query.parser.Part;
+import org.springframework.data.repository.query.parser.PartTree;
+
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+
+/**
+ * @author Christoph Strobl
+ */
+public class HazelcastQueryCreator extends AbstractQueryCreator<KeyValueQuery<Predicate<?, ?>>, Predicate<?, ?>> {
+
+	private final PredicateBuilder predicateBuilder;
+
+	/**
+	 * Creates a new {@link EhCacheQueryCreator} for the given {@link PartTree}.
+	 * 
+	 * @param tree must not be {@literal null}.
+	 */
+	public HazelcastQueryCreator(PartTree tree) {
+
+		super(tree);
+		this.predicateBuilder = new PredicateBuilder();
+	}
+
+	/**
+	 * Creates a new {@link HazelcastQueryCreator} for the given {@link PartTree} and {@link ParameterAccessor}. The
+	 * latter is used to hand actual parameter values into the callback methods as well as to apply dynamic sorting via a
+	 * {@link Sort} parameter.
+	 * 
+	 * @param tree must not be {@literal null}.
+	 * @param parameters can be {@literal null}.
+	 */
+	public HazelcastQueryCreator(PartTree tree, ParameterAccessor parameters) {
+		super(tree, parameters);
+		this.predicateBuilder = new PredicateBuilder();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.parser.AbstractQueryCreator#create(org.springframework.data.repository.query.parser.Part, java.util.Iterator)
+	 */
+	@Override
+	protected Predicate<?, ?> create(Part part, Iterator<Object> iterator) {
+		return from(predicateBuilder, part, iterator);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.parser.AbstractQueryCreator#and(org.springframework.data.repository.query.parser.Part, java.lang.Object, java.util.Iterator)
+	 */
+	@Override
+	protected Predicate<?, ?> and(Part part, Predicate<?, ?> base, Iterator<Object> iterator) {
+		return predicateBuilder.and(from(predicateBuilder, part, iterator));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.parser.AbstractQueryCreator#or(java.lang.Object, java.lang.Object)
+	 */
+	@Override
+	protected Predicate<?, ?> or(Predicate<?, ?> base, Predicate<?, ?> criteria) {
+		return predicateBuilder.or(criteria);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.parser.AbstractQueryCreator#complete(java.lang.Object, org.springframework.data.domain.Sort)
+	 */
+	@Override
+	protected KeyValueQuery<Predicate<?, ?>> complete(Predicate<?, ?> criteria, Sort sort) {
+		return new KeyValueQuery<Predicate<?, ?>>(criteria);
+	}
+
+	private Predicate<?, ?> from(PredicateBuilder pb, Part part, Iterator<Object> iterator) {
+
+		EntryObject e = pb.getEntryObject();
+		e.get(part.getProperty().toDotPath());
+
+		switch (part.getType()) {
+			case TRUE:
+				return e.equal(true);
+			case FALSE:
+				return e.equal(false);
+			case SIMPLE_PROPERTY:
+				return e.equal((Comparable<?>) iterator.next());
+			case IS_NULL:
+				return e.isNull();
+			case GREATER_THAN:
+				return e.greaterThan((Comparable<?>) iterator.next());
+
+			default:
+				throw new InvalidDataAccessApiUsageException(String.format("Found invalid part '%s' in query", part.getType()));
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/hazelcast/HazelcastUtils.java
+++ b/src/test/java/org/springframework/data/hazelcast/HazelcastUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast;
+
+import org.springframework.data.hazelcast.HazelcastKeyValueAdapter;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+
+/**
+ * @author Christoph Strobl
+ */
+public class HazelcastUtils {
+
+	static Config hazelcastConfig() {
+
+		Config hazelcastConfig = new Config();
+		hazelcastConfig.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+		hazelcastConfig.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
+		hazelcastConfig.getNetworkConfig().getJoin().getAwsConfig().setEnabled(false);
+
+		return hazelcastConfig;
+	}
+
+	public static HazelcastKeyValueAdapter preconfiguredHazelcastKeyValueAdapter() {
+		return new HazelcastKeyValueAdapter(Hazelcast.newHazelcastInstance(hazelcastConfig()));
+	}
+
+}

--- a/src/test/java/org/springframework/data/hazelcast/KeyValueTemplateTestsUsingHazelcast.java
+++ b/src/test/java/org/springframework/data/hazelcast/KeyValueTemplateTestsUsingHazelcast.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.Serializable;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Persistent;
+import org.springframework.data.keyvalue.annotation.KeySpace;
+import org.springframework.data.keyvalue.core.KeyValueTemplate;
+import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+import org.springframework.util.ObjectUtils;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+
+/**
+ * @author Christoph Strobl
+ */
+public class KeyValueTemplateTestsUsingHazelcast {
+
+	private static final Foo FOO_ONE = new Foo("one");
+	private static final Foo FOO_TWO = new Foo("two");
+	private static final Foo FOO_THREE = new Foo("three");
+	private static final Bar BAR_ONE = new Bar("one");
+	private static final ClassWithTypeAlias ALIASED = new ClassWithTypeAlias("super");
+	private static final SubclassOfAliasedType SUBCLASS_OF_ALIASED = new SubclassOfAliasedType("sub");
+
+	private static final KeyValueQuery<Predicate<?, ?>> HAZELCAST_QUERY = new KeyValueQuery<Predicate<?, ?>>(
+			new PredicateBuilder().getEntryObject().get("foo").equal("two"));
+
+	private KeyValueTemplate operations;
+
+	@Before
+	public void setUp() throws InstantiationException, IllegalAccessException {
+		this.operations = new KeyValueTemplate(HazelcastUtils.preconfiguredHazelcastKeyValueAdapter());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		this.operations.destroy();
+	}
+
+	@Test
+	public void insertShouldNotThorwErrorWhenExecutedHavingNonExistingIdAndNonNullValue() {
+		operations.insert("1", FOO_ONE);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void insertShouldThrowExceptionForNullId() {
+		operations.insert(null, FOO_ONE);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void insertShouldThrowExceptionForNullObject() {
+		operations.insert("some-id", null);
+	}
+
+	@Test(expected = InvalidDataAccessApiUsageException.class)
+	public void insertShouldThrowExecptionWhenObjectOfSameTypeAlreadyExists() {
+
+		operations.insert("1", FOO_ONE);
+		operations.insert("1", FOO_TWO);
+	}
+
+	@Test
+	public void insertShouldWorkCorrectlyWhenObjectsOfDifferentTypesWithSameIdAreInserted() {
+
+		operations.insert("1", FOO_ONE);
+		operations.insert("1", BAR_ONE);
+	}
+
+	@Test
+	public void createShouldReturnSameInstanceGenerateId() {
+
+		ClassWithStringId source = new ClassWithStringId();
+		ClassWithStringId target = operations.insert(source);
+
+		assertThat(target, sameInstance(source));
+	}
+
+	@Test
+	public void createShouldRespectExistingId() {
+
+		ClassWithStringId source = new ClassWithStringId();
+		source.id = "one";
+
+		operations.insert(source);
+
+		assertThat(operations.findById("one", ClassWithStringId.class), is(source));
+	}
+
+	@Test
+	public void findByIdShouldReturnObjectWithMatchingIdAndType() {
+
+		operations.insert("1", FOO_ONE);
+		assertThat(operations.findById("1", Foo.class), is(FOO_ONE));
+	}
+
+	@Test
+	public void findByIdSouldReturnNullIfNoMatchingIdFound() {
+
+		operations.insert("1", FOO_ONE);
+		assertThat(operations.findById("2", Foo.class), nullValue());
+	}
+
+	@Test
+	public void findByIdShouldReturnNullIfNoMatchingTypeFound() {
+
+		operations.insert("1", FOO_ONE);
+		assertThat(operations.findById("1", Bar.class), nullValue());
+	}
+
+	@Test
+	public void findShouldExecuteQueryCorrectly() {
+
+		operations.insert("1", FOO_ONE);
+		operations.insert("2", FOO_TWO);
+
+		List<Foo> result = (List<Foo>) operations.find(HAZELCAST_QUERY, Foo.class);
+		assertThat(result, hasSize(1));
+		assertThat(result.get(0), is(FOO_TWO));
+	}
+
+	@Test
+	public void readShouldReturnEmptyCollectionIfOffsetOutOfRange() {
+
+		operations.insert("1", FOO_ONE);
+		operations.insert("2", FOO_TWO);
+		operations.insert("3", FOO_THREE);
+
+		assertThat(operations.findInRange(5, 5, Foo.class), empty());
+	}
+
+	@Test
+	public void updateShouldReplaceExistingObject() {
+
+		operations.insert("1", FOO_ONE);
+		operations.update("1", FOO_TWO);
+		assertThat(operations.findById("1", Foo.class), is(FOO_TWO));
+	}
+
+	@Test
+	public void updateShouldRespectTypeInformation() {
+
+		operations.insert("1", FOO_ONE);
+		operations.update("1", BAR_ONE);
+
+		assertThat(operations.findById("1", Foo.class), is(FOO_ONE));
+	}
+
+	@Test
+	public void deleteShouldRemoveObjectCorrectly() {
+
+		operations.insert("1", FOO_ONE);
+		operations.delete("1", Foo.class);
+		assertThat(operations.findById("1", Foo.class), nullValue());
+	}
+
+	@Test
+	public void deleteReturnsNullWhenNotExisting() {
+
+		operations.insert("1", FOO_ONE);
+		assertThat(operations.delete("2", Foo.class), nullValue());
+	}
+
+	@Test
+	public void deleteReturnsRemovedObject() {
+
+		operations.insert("1", FOO_ONE);
+		assertThat(operations.delete("1", Foo.class), is(FOO_ONE));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void deleteThrowsExceptionWhenIdCannotBeExctracted() {
+		operations.delete(FOO_ONE);
+	}
+
+	@Test
+	public void countShouldReturnZeroWhenNoElementsPresent() {
+		assertThat(operations.count(Foo.class), is(0L));
+	}
+
+	@Test
+	public void insertShouldRespectTypeAlias() {
+
+		operations.insert("1", ALIASED);
+		operations.insert("2", SUBCLASS_OF_ALIASED);
+
+		assertThat(operations.findAll(ALIASED.getClass()), containsInAnyOrder(ALIASED, SUBCLASS_OF_ALIASED));
+	}
+
+	static class Foo implements Serializable {
+
+		String foo;
+
+		public Foo(String foo) {
+			this.foo = foo;
+		}
+
+		public String getFoo() {
+			return foo;
+		}
+
+		@Override
+		public int hashCode() {
+			return ObjectUtils.nullSafeHashCode(this.foo);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (!(obj instanceof Foo)) {
+				return false;
+			}
+			Foo other = (Foo) obj;
+			return ObjectUtils.nullSafeEquals(this.foo, other.foo);
+		}
+
+	}
+
+	static class Bar implements Serializable {
+
+		String bar;
+
+		public Bar(String bar) {
+			this.bar = bar;
+		}
+
+		public String getBar() {
+			return bar;
+		}
+
+		@Override
+		public int hashCode() {
+			return ObjectUtils.nullSafeHashCode(this.bar);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (!(obj instanceof Bar)) {
+				return false;
+			}
+			Bar other = (Bar) obj;
+			return ObjectUtils.nullSafeEquals(this.bar, other.bar);
+		}
+
+	}
+
+	static class ClassWithStringId implements Serializable {
+
+		@Id String id;
+		String value;
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ObjectUtils.nullSafeHashCode(this.id);
+			result = prime * result + ObjectUtils.nullSafeHashCode(this.value);
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (!(obj instanceof ClassWithStringId)) {
+				return false;
+			}
+			ClassWithStringId other = (ClassWithStringId) obj;
+			if (!ObjectUtils.nullSafeEquals(this.id, other.id)) {
+				return false;
+			}
+			if (!ObjectUtils.nullSafeEquals(this.value, other.value)) {
+				return false;
+			}
+			return true;
+		}
+
+	}
+
+	@ExplicitKeySpace(name = "aliased")
+	static class ClassWithTypeAlias implements Serializable {
+
+		@Id String id;
+		String name;
+
+		public ClassWithTypeAlias(String name) {
+			this.name = name;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ObjectUtils.nullSafeHashCode(this.id);
+			result = prime * result + ObjectUtils.nullSafeHashCode(this.name);
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (!(obj instanceof ClassWithTypeAlias)) {
+				return false;
+			}
+			ClassWithTypeAlias other = (ClassWithTypeAlias) obj;
+			if (!ObjectUtils.nullSafeEquals(this.id, other.id)) {
+				return false;
+			}
+			if (!ObjectUtils.nullSafeEquals(this.name, other.name)) {
+				return false;
+			}
+			return true;
+		}
+
+	}
+
+	static class SubclassOfAliasedType extends ClassWithTypeAlias {
+
+		public SubclassOfAliasedType(String name) {
+			super(name);
+		}
+
+	}
+
+	@Documented
+	@Persistent
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.TYPE })
+	private static @interface ExplicitKeySpace {
+
+		@KeySpace
+		String name() default "";
+
+	}
+}

--- a/src/test/java/org/springframework/data/hazelcast/KeyValueTemplateTestsUsingHazelcast.java
+++ b/src/test/java/org/springframework/data/hazelcast/KeyValueTemplateTestsUsingHazelcast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Persistent;
 import org.springframework.data.keyvalue.annotation.KeySpace;
@@ -41,8 +41,12 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder;
 
 /**
+ * Unit tests for {@link KeyValueTemplate} using a {@link HazelcastKeyValueAdapter}.
+ * 
  * @author Christoph Strobl
+ * @author Oliver Gierke
  */
+@SuppressWarnings("serial")
 public class KeyValueTemplateTestsUsingHazelcast {
 
 	private static final Foo FOO_ONE = new Foo("one");
@@ -82,7 +86,7 @@ public class KeyValueTemplateTestsUsingHazelcast {
 		operations.insert("some-id", null);
 	}
 
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = DuplicateKeyException.class)
 	public void insertShouldThrowExecptionWhenObjectOfSameTypeAlreadyExists() {
 
 		operations.insert("1", FOO_ONE);

--- a/src/test/java/org/springframework/data/hazelcast/repository/config/EnableHazelcastRepositoriesIntegrationTests.java
+++ b/src/test/java/org/springframework/data/hazelcast/repository/config/EnableHazelcastRepositoriesIntegrationTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hazelcast.repository.config;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.hazelcast.HazelcastUtils;
+import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.keyvalue.core.KeyValueTemplate;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration test for Hazelcast repositories.
+ * 
+ * @author Christoph Strobl
+ * @author Oliver Gierke
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class EnableHazelcastRepositoriesIntegrationTests {
+
+	@Configuration
+	@EnableHazelcastRepositories(considerNestedRepositories = true)
+	static class Config {
+
+		@Bean
+		public KeyValueOperations keyValueTemplate() {
+			return new KeyValueTemplate(HazelcastUtils.preconfiguredHazelcastKeyValueAdapter());
+		}
+	}
+
+	@Autowired PersonRepository repo;
+
+	@Test
+	public void shouldEnableKeyValueRepositoryCorrectly() {
+
+		assertThat(repo, notNullValue());
+
+		Person person = new Person();
+		person.setFirstname("foo");
+		repo.save(person);
+
+		List<Person> result = repo.findByFirstname("foo");
+
+		assertThat(result, hasSize(1));
+		assertThat(result.get(0).firstname, is("foo"));
+	}
+
+	static class Person implements Serializable {
+
+		private static final long serialVersionUID = -1654603912377346292L;
+
+		@Id String id;
+		String firstname;
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getFirstname() {
+			return firstname;
+		}
+
+		public void setFirstname(String firstname) {
+			this.firstname = firstname;
+		}
+
+	}
+
+	static interface PersonRepository extends CrudRepository<Person, String> {
+
+		List<Person> findByFirstname(String firstname);
+	}
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d %5p %40.40c:%4L - %m%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.springframework.data" level="warn" />
+
+	<root level="warn">
+		<appender-ref ref="console" />
+	</root>
+
+</configuration>

--- a/template.mf
+++ b/template.mf
@@ -1,0 +1,11 @@
+Bundle-SymbolicName: org.springframework.data.hazelcast
+Bundle-Name: ${project.name}
+Bundle-Vendor: Hazelcast, Inc., Pivotal Software, Inc.
+Bundle-Version: ${project.version}
+Bundle-ManifestVersion: 2
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Import-Template:
+ com.hazelcast.*;version="${hazelcast:[=.=.=,+1.0.0)}";resolution:=optional,
+ org.springframework.*;version="${spring:[=.=.=,+1.0.0)}",
+ org.springframework.data.*;version="${springdata.commons:[=.=.=,+1.0.0)}"
+DynamicImport-Package: *


### PR DESCRIPTION
This commit adds the necessary infrastructure for Hazelcast based Spring Data repositories. See the configuration class in EnableHazelcastRepositoriesIntegrationTests for details.