### PR TITLE
HazelcastKeyValueAdapter instance ctor

### DIFF
--- a/src/main/java/org/springframework/data/hazelcast/HazelcastKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/hazelcast/HazelcastKeyValueAdapter.java
@@ -39,9 +39,13 @@ public class HazelcastKeyValueAdapter extends AbstractKeyValueAdapter {
 	private HazelcastInstance hzInstance;
 
 	public HazelcastKeyValueAdapter() {
+		this(Hazelcast.getOrCreateHazelcastInstance(new Config(Constants.HAZELCAST_INSTANCE_NAME)));
+	}
+
+	public HazelcastKeyValueAdapter(HazelcastInstance hzInstance) {
 		super(new HazelcastQueryEngine());
-		Config cfg = new Config(Constants.HAZELCAST_INSTANCE_NAME);
-		this.hzInstance = Hazelcast.getOrCreateHazelcastInstance(cfg);
+		Assert.notNull(hzInstance, "hzInstance must not be 'null'.");
+		this.hzInstance = hzInstance;
 	}
 
 	public void setHzInstance(HazelcastInstance hzInstance) {

--- a/src/test/java/org/springframework/data/hazelcast/HazelcastUtils.java
+++ b/src/test/java/org/springframework/data/hazelcast/HazelcastUtils.java
@@ -36,8 +36,7 @@ public class HazelcastUtils {
 
 	public static HazelcastKeyValueAdapter preconfiguredHazelcastKeyValueAdapter() {
 		HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(hazelcastConfig());
-		HazelcastKeyValueAdapter hazelcastKeyValueAdapter = new HazelcastKeyValueAdapter();
-		hazelcastKeyValueAdapter.setHzInstance(hazelcastInstance);
+		HazelcastKeyValueAdapter hazelcastKeyValueAdapter = new HazelcastKeyValueAdapter(hazelcastInstance);
 		return hazelcastKeyValueAdapter;
 	}
 

--- a/src/test/java/test/utils/InstanceHelper.java
+++ b/src/test/java/test/utils/InstanceHelper.java
@@ -75,8 +75,7 @@ public class InstanceHelper {
 	 */
 	@Bean
 	public KeyValueOperations keyValueTemplate() {
-		HazelcastKeyValueAdapter hazelcastKeyValueAdapter = new HazelcastKeyValueAdapter();
-		hazelcastKeyValueAdapter.setHzInstance(this.hazelcastInstance);
+		HazelcastKeyValueAdapter hazelcastKeyValueAdapter = new HazelcastKeyValueAdapter(this.hazelcastInstance);
 		return new KeyValueTemplate(hazelcastKeyValueAdapter);
 	}
 


### PR DESCRIPTION
 - Reintroduce the HazelcastKeyValueAdapter constructor that takes a
   HazelcastInstance
 - Reinstate backward compatibility with code that used it