### PR TITLE
Add configuration with defining only HazelcastInstance Bean

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,22 +77,11 @@ public class ApplicationConfiguration {
         return Hazelcast.newHazelcastInstance();
         // return HazelcastClient.newHazelcastClient();
     }
-
-    @Bean
-    public KeyValueOperations keyValueTemplate(HazelcastInstance hazelcastInstance) {  // <3>
-        return new KeyValueTemplate(new HazelcastKeyValueAdapter(hazelcastInstance));
-    }
-
-    @Bean
-    public HazelcastKeyValueAdapter hazelcastKeyValueAdapter(HazelcastInstance hazelcastInstance) {
-        return new HazelcastKeyValueAdapter(hazelcastInstance);
-    }
 }
 ----
 <1> Enables Spring Data magic for Hazelcast. 
     You can specify `basePackages` for component scan.
 <2> Instantiates Hazelcast instance (a member or a client)
-<3> Instantiates KV template
 
 .A repository class definition
 [source,java]

--- a/src/main/java/org/springframework/data/hazelcast/repository/config/EnableHazelcastRepositories.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/config/EnableHazelcastRepositories.java
@@ -40,6 +40,7 @@ import java.lang.annotation.Target;
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Neil Stevenson
+ * @author Rafal Leszko
  */
 @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
@@ -131,4 +132,11 @@ public @interface EnableHazelcastRepositories {
      * repositories infrastructure.
      */
     boolean considerNestedRepositories() default false;
+
+    /**
+     * Configures the bean name of the {@link HazelcastInstance} to be used. Defaulted to {@literal hazelcastInstance}.
+     *
+     * @return
+     */
+    String hazelcastInstanceRef() default "hazelcastInstance";
 }

--- a/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoriesRegistrar.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.hazelcast.repository.config;
 
-import org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension;
 import org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 
@@ -27,6 +26,7 @@ import java.lang.annotation.Annotation;
  *
  * @author Oliver Gierke
  * @author Neil Stevenson
+ * @author Rafal Leszko
  */
 class HazelcastRepositoriesRegistrar
         extends RepositoryBeanDefinitionRegistrarSupport {
@@ -49,42 +49,4 @@ class HazelcastRepositoriesRegistrar
         return new HazelcastRepositoryConfigurationExtension();
     }
 
-    /**
-     * Hazelcast-specific {@link RepositoryConfigurationExtension}.
-     *
-     * @author Oliver Gierke
-     */
-    private static class HazelcastRepositoryConfigurationExtension
-            extends KeyValueRepositoryConfigurationExtension {
-
-        /*
-         * (non-Javadoc)
-         * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension
-         *                          #getModuleName()
-         */
-        @Override
-        public String getModuleName() {
-            return "Hazelcast";
-        }
-
-        /*
-         * (non-Javadoc)
-         * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension
-         *                          #getModulePrefix()
-         */
-        @Override
-        protected String getModulePrefix() {
-            return "hazelcast";
-        }
-
-        /*
-         * (non-Javadoc)
-         * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension
-         *                          #getDefaultKeyValueTemplateRef()
-         */
-        @Override
-        protected String getDefaultKeyValueTemplateRef() {
-            return "keyValueTemplate";
-        }
-    }
 }

--- a/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/config/HazelcastRepositoryConfigurationExtension.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.hazelcast.repository.config;
+
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.data.hazelcast.HazelcastKeyValueAdapter;
+import org.springframework.data.keyvalue.core.KeyValueTemplate;
+import org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+import org.springframework.data.repository.config.RepositoryConfigurationSource;
+
+/**
+ * Hazelcast-specific {@link RepositoryConfigurationExtension}.
+ *
+ * @author Oliver Gierke
+ * @author Rafal Leszko
+ */
+class HazelcastRepositoryConfigurationExtension
+        extends KeyValueRepositoryConfigurationExtension {
+
+    private static final String HAZELCAST_ADAPTER_BEAN_NAME = "hazelcastKeyValueAdapter";
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension
+     *                          #getModuleName()
+     */
+    @Override
+    public String getModuleName() {
+        return "Hazelcast";
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension
+     *                          #getModulePrefix()
+     */
+    @Override
+    protected String getModulePrefix() {
+        return "hazelcast";
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension
+     *                          #getDefaultKeyValueTemplateRef()
+     */
+    @Override
+    protected String getDefaultKeyValueTemplateRef() {
+        return "keyValueTemplate";
+    }
+
+    @Override
+    public void registerBeansForRoot(BeanDefinitionRegistry registry, RepositoryConfigurationSource configurationSource) {
+        // register HazelcastKeyValueAdapter
+        String hazelcastInstanceRef = configurationSource.getAttribute("hazelcastInstanceRef").get();
+
+        RootBeanDefinition hazelcastKeyValueAdapterDefinition = new RootBeanDefinition(HazelcastKeyValueAdapter.class);
+        ConstructorArgumentValues constructorArgumentValuesForHazelcastKeyValueAdapter = new ConstructorArgumentValues();
+        constructorArgumentValuesForHazelcastKeyValueAdapter
+                .addIndexedArgumentValue(0, new RuntimeBeanReference(hazelcastInstanceRef));
+        hazelcastKeyValueAdapterDefinition.setConstructorArgumentValues(constructorArgumentValuesForHazelcastKeyValueAdapter);
+        registerIfNotAlreadyRegistered(hazelcastKeyValueAdapterDefinition, registry, HAZELCAST_ADAPTER_BEAN_NAME,
+                configurationSource);
+
+        super.registerBeansForRoot(registry, configurationSource);
+    }
+
+    @Override
+    protected AbstractBeanDefinition getDefaultKeyValueTemplateBeanDefinition(RepositoryConfigurationSource configurationSource) {
+        RootBeanDefinition keyValueTemplateDefinition = new RootBeanDefinition(KeyValueTemplate.class);
+        ConstructorArgumentValues constructorArgumentValuesForKeyValueTemplate = new ConstructorArgumentValues();
+        constructorArgumentValuesForKeyValueTemplate
+                .addIndexedArgumentValue(0, new RuntimeBeanReference(HAZELCAST_ADAPTER_BEAN_NAME));
+        constructorArgumentValuesForKeyValueTemplate
+                .addIndexedArgumentValue(1, new RuntimeBeanReference(MAPPING_CONTEXT_BEAN_NAME));
+
+        keyValueTemplateDefinition.setConstructorArgumentValues(constructorArgumentValuesForKeyValueTemplate);
+
+        return keyValueTemplateDefinition;
+    }
+
+}

--- a/src/test/java/test/utils/InstanceHelper.java
+++ b/src/test/java/test/utils/InstanceHelper.java
@@ -27,10 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.hazelcast.HazelcastKeyValueAdapter;
 import org.springframework.data.hazelcast.repository.config.EnableHazelcastRepositories;
-import org.springframework.data.keyvalue.core.KeyValueOperations;
-import org.springframework.data.keyvalue.core.KeyValueTemplate;
 import test.utils.repository.custom.MyTitleRepositoryFactoryBean;
 
 import javax.annotation.PreDestroy;
@@ -53,7 +50,7 @@ import java.util.Set;
  * @author Neil Stevenson
  */
 @Configuration
-@EnableHazelcastRepositories(basePackages = "test.utils.repository.standard")
+@EnableHazelcastRepositories(basePackages = "test.utils.repository.standard", hazelcastInstanceRef = TestConstants.CLIENT_INSTANCE_NAME)
 public class InstanceHelper {
     private static final Logger LOG = LoggerFactory.getLogger(InstanceHelper.class);
     private static final String CLUSTER_HOST = "127.0.0.1";
@@ -120,21 +117,6 @@ public class InstanceHelper {
 
     /**
      * <p>
-     * {@link org.springframework.data.keyvalue.core.KeyValueOperations KeyValueOperations} are implemented by a
-     * {@link org.springframework.data.keyvalue.core.KeyValueTemplate KeyValueTemplate} that uses an adapter class
-     * encapsulating the implementation.
-     * </P>
-     *
-     * @return One Hazelcast instance wrapped as a key/value implementation
-     */
-    @Bean
-    public KeyValueOperations keyValueTemplate() {
-        HazelcastKeyValueAdapter hazelcastKeyValueAdapter = new HazelcastKeyValueAdapter(this.hazelcastInstance);
-        return new KeyValueTemplate(hazelcastKeyValueAdapter);
-    }
-
-    /**
-     * <p>
      * Spring will shutdown the test Hazelcast instance, as the {@code @Bean} is defined as a
      * {@link org.springframework.beans.factory.DisposableBean}. Shut down any other server instances started, which may
      * be needed for cluster tests.
@@ -168,7 +150,7 @@ public class InstanceHelper {
      * so use an inner class to scan a second package.
      * </P>
      */
-    @EnableHazelcastRepositories(basePackages = "test.utils.repository.custom", repositoryFactoryBeanClass = MyTitleRepositoryFactoryBean.class)
+    @EnableHazelcastRepositories(basePackages = "test.utils.repository.custom", repositoryFactoryBeanClass = MyTitleRepositoryFactoryBean.class, hazelcastInstanceRef = TestConstants.CLIENT_INSTANCE_NAME)
     static class InstanceHelperInner {
     }
 


### PR DESCRIPTION
Before, in order to configure Spring Data Hazelcast, you needed to create HazelcastInstance, HazelcastKeyValueAdapter, and KeyValueTemplate.

Changes:
- Add registering beans to HazelcastRepositoryConfigurationExtension
- Extract HazelcastRepositoryConfigurationExtension from HazelcastRepositoriesRegistrar

fix #11 