### PR TITLE
Fix issue with rearrange when parameters include special types (e.g. …

### DIFF
--- a/src/main/java/org/springframework/data/hazelcast/repository/query/HazelcastPartTreeQuery.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/query/HazelcastPartTreeQuery.java
@@ -326,7 +326,7 @@ public class HazelcastPartTreeQuery
             parameters = new Object[originalParameters.length];
 
             for (int i = 0; i < parameters.length; i++) {
-                int index = rearrangeIndex[i];
+                int index = (i < rearrangeIndex.length) ? rearrangeIndex[i] : i;
                 parameters[i] = originalParameters[index];
             }
         }

--- a/src/test/java/org/springframework/data/hazelcast/repository/PagingSortingIT.java
+++ b/src/test/java/org/springframework/data/hazelcast/repository/PagingSortingIT.java
@@ -120,6 +120,9 @@ public class PagingSortingIT
         firstPageOf20Content.forEach(person -> ids.add(person.getId()));
 
         assertThat("20 different years", ids.size(), equalTo(20));
+            
+        Page<Person> firstPageOfParamResponse = this.personRepository.findAllById("1933", firstPageOf20Request);
+        assertThat("1 onwards returned for @Param query", firstPageOfParamResponse, notNullValue());
     }
 
     @Test

--- a/src/test/java/org/springframework/data/hazelcast/repository/PagingSortingIT.java
+++ b/src/test/java/org/springframework/data/hazelcast/repository/PagingSortingIT.java
@@ -120,9 +120,6 @@ public class PagingSortingIT
         firstPageOf20Content.forEach(person -> ids.add(person.getId()));
 
         assertThat("20 different years", ids.size(), equalTo(20));
-            
-        Page<Person> firstPageOfParamResponse = this.personRepository.findAllById("1933", firstPageOf20Request);
-        assertThat("1 onwards returned for @Param query", firstPageOfParamResponse, notNullValue());
     }
 
     @Test

--- a/src/test/java/org/springframework/data/hazelcast/repository/query/QueryIT.java
+++ b/src/test/java/org/springframework/data/hazelcast/repository/query/QueryIT.java
@@ -663,6 +663,15 @@ public class QueryIT
 
         assertThat("All lastnames matched", lastnames, hasSize(0));
     }
+    
+    @Test
+    public void findByIdPagedWithParam() {
+    	int PAGE_0 = 0;
+        int SIZE_20 = 20;
+        PageRequest firstPageOf20Request = PageRequest.of(PAGE_0, SIZE_20);
+    	Page<Person> firstPageOfParamResponse = this.personRepository.findAllById("1933", firstPageOf20Request);
+        assertThat("1 onwards returned for @Param query", firstPageOfParamResponse, notNullValue());
+    }
 
     // Delete methods
 
@@ -822,12 +831,4 @@ public class QueryIT
         assertThat(result.get(), containsInAnyOrder(person1, person2));
     }
     
-    @Test
-    public void findByIdPagedWithParam() {
-    	int PAGE_0 = 0;
-        int SIZE_20 = 20;
-        PageRequest firstPageOf20Request = PageRequest.of(PAGE_0, SIZE_20);
-    	Page<Person> firstPageOfParamResponse = this.personRepository.findAllById("1933", firstPageOf20Request);
-        assertThat("1 onwards returned for @Param query", firstPageOfParamResponse, notNullValue());
-    }
 }

--- a/src/test/java/org/springframework/data/hazelcast/repository/query/QueryIT.java
+++ b/src/test/java/org/springframework/data/hazelcast/repository/query/QueryIT.java
@@ -821,4 +821,13 @@ public class QueryIT
         // then
         assertThat(result.get(), containsInAnyOrder(person1, person2));
     }
+    
+    @Test
+    public void findByIdPagedWithParam() {
+    	int PAGE_0 = 0;
+        int SIZE_20 = 20;
+        PageRequest firstPageOf20Request = PageRequest.of(PAGE_0, SIZE_20);
+    	Page<Person> firstPageOfParamResponse = this.personRepository.findAllById("1933", firstPageOf20Request);
+        assertThat("1 onwards returned for @Param query", firstPageOfParamResponse, notNullValue());
+    }
 }

--- a/src/test/java/test/utils/repository/standard/PersonRepository.java
+++ b/src/test/java/test/utils/repository/standard/PersonRepository.java
@@ -150,6 +150,8 @@ public interface PersonRepository
                                                                                                   String firstname2,
                                                                                                   Pageable pageable);
 
+    public Page<Person> findAllById(@Param("id") String id, Pageable pageable);
+        
     // Delete methods
 
     public long deleteByLastname(String firstname);


### PR DESCRIPTION
…Sort or Pageable)

When parameters to a method include special types such as a PageRequest, the prepareAccessor method will throw an IndexOutOfBoundsException on line 329 because the rearrangeIndex array only concerns itself with bindable parameters.