### PR TITLE
spring's default behaviour to resolve keyspace

### DIFF
--- a/src/main/java/org/springframework/data/hazelcast/repository/support/HazelcastQueryMethod.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/support/HazelcastQueryMethod.java
@@ -49,9 +49,10 @@ public class HazelcastQueryMethod
     }
 
     String getKeySpace() {
-        KeySpace keySpace = getEntityInformation().getJavaType().getAnnotation(KeySpace.class);
+        Class<?> clazz = getEntityInformation().getJavaType();
+        KeySpace keySpace = clazz.getAnnotation(KeySpace.class);
         String queryString = (keySpace != null ? (String) AnnotationUtils.getValue(keySpace) : null);
-        return (StringUtils.hasText(queryString) ? queryString : null);
+        return (StringUtils.hasText(queryString) ? queryString : clazz.getName());
 
     }
 


### PR DESCRIPTION
Based on, https://stackoverflow.com/questions/59580063/spring-data-hazelcast-query-annotation-gives-nullpointerexception/59670975

Without `@KeySpace` annotation `spring-data-hazelcast` can put objects properly. And spring sets class name as the key.  Normally spring-data-hazelcast intercepts keyspace value on its own method so when `@KeySpace` value is null, it returns null.

When I investigated spring data default behavior, it `@KeySpace` annotation is null, it resolves(assumes) class name as keySpace value. So added this default feature.

See in default resolver:[AnnotationBasedKeySpaceResolver.class](https://github.com/spring-projects/spring-data-keyvalue/blob/master/src/main/java/org/springframework/data/keyvalue/core/mapping/AnnotationBasedKeySpaceResolver.java)