### PR TITLE
Remove redundant assertion

### DIFF
--- a/src/test/java/org/springframework/data/hazelcast/repository/PagingSortingIT.java
+++ b/src/test/java/org/springframework/data/hazelcast/repository/PagingSortingIT.java
@@ -72,7 +72,6 @@ public class PagingSortingIT
         assertThat("First page is returned", page.getNumber(), equalTo(0));
         assertThat("First page count matches content", page.getNumberOfElements(), equalTo(content.size()));
         assertThat("First page has all content", (long) page.getNumberOfElements(), equalTo(page.getTotalElements()));
-        assertThat("First page has no upper limit", page.getSize(), equalTo(0));
         assertThat("First page has correct content count", page.getNumberOfElements(), equalTo(TestData.bestActors.length));
         assertThat("First page is only page", page.getTotalPages(), equalTo(1));
     }


### PR DESCRIPTION
Removing redundant assertion verifying paging implementation detail - a page size.

In this scenario, we only need to assert if the first (and the only) page contains all the data, the actual upper limit of the page is irrelevant.

----
fixes https://github.com/hazelcast/spring-data-hazelcast/issues/102

