### PR TITLE
Fix integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,9 @@
                         <include>**/Test*.java</include>
                         <include>**/*Test.java</include>
                         <include>**/*TestCase.java</include>
+                        <include>**/IT*.java</include>
+                        <include>**/*IT.java</include>
+                        <include>**/*ITCase.java</include>
                     </includes>
                 </configuration>
                 <executions>
@@ -305,7 +308,6 @@
                             </includes>
                         </configuration>
                         <executions>
-
                             <execution>
                                 <id>default-integration-test</id>
                                 <goals>

--- a/src/test/java/org/springframework/data/hazelcast/repository/support/HazelcastEntityInformationTest.java
+++ b/src/test/java/org/springframework/data/hazelcast/repository/support/HazelcastEntityInformationTest.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.hazelcast.repository.support;
 
+import com.hazelcast.core.Hazelcast;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.hazelcast.HazelcastUtils;
@@ -37,5 +39,10 @@ public class HazelcastEntityInformationTest {
     public void throwsMappingExceptionWhenNoIdPropertyPresent() {
         PersistentEntity<?, ?> persistentEntity = operations.getMappingContext().getPersistentEntity(NoIdEntity.class);
         new HazelcastEntityInformation<>(persistentEntity);
+    }
+
+    @AfterClass
+    public static void close() {
+        Hazelcast.shutdownAll();
     }
 }

--- a/src/test/java/test/utils/TestDataHelper.java
+++ b/src/test/java/test/utils/TestDataHelper.java
@@ -17,9 +17,11 @@
 package test.utils;
 
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -200,4 +202,8 @@ public abstract class TestDataHelper {
 
     }
 
+    @AfterClass
+    public static void close() {
+        Hazelcast.shutdownAll();
+    }
 }


### PR DESCRIPTION
This is just the first step towards cleaning up integration tests for `spring-data-hazelcast`.

Ensuring that tests clean up after themselves and including them in the default build.