### PR TITLE
Hook to provide a Comparator for the cache sort

### DIFF
--- a/src/main/java/org/springframework/data/hazelcast/repository/query/HazelcastSortAccessor.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/query/HazelcastSortAccessor.java
@@ -18,6 +18,7 @@ package org.springframework.data.hazelcast.repository.query;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.NullHandling;
 import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.hazelcast.repository.support.WithComparatorSort;
 import org.springframework.data.keyvalue.core.SortAccessor;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 
@@ -48,13 +49,17 @@ public class HazelcastSortAccessor
      */
     public Comparator<Entry<?, ?>> resolve(KeyValueQuery<?> query) {
 
-        if (query == null || query.getSort() == Sort.unsorted()) {
+        final Sort sort;
+        if (query == null || (sort = query.getSort()) == Sort.unsorted()) {
             return null;
         }
 
+        if (sort instanceof WithComparatorSort) {
+            return ((WithComparatorSort) sort).getComparator();
+        }
         Comparator hazelcastPropertyComparator = null;
 
-        for (Order order : query.getSort()) {
+        for (Order order : sort) {
 
             if (order.getProperty().indexOf('.') > -1) {
                 throw new UnsupportedOperationException("Embedded fields not implemented: " + order);

--- a/src/main/java/org/springframework/data/hazelcast/repository/support/WithComparatorSort.java
+++ b/src/main/java/org/springframework/data/hazelcast/repository/support/WithComparatorSort.java
@@ -1,0 +1,25 @@
+package org.springframework.data.hazelcast.repository.support;
+
+import org.springframework.data.domain.Sort;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map.Entry;
+
+/**
+ * A special {@link Sort} that provides a {@link Comparator} for more optimized sorts (because Reflection which is by default is slow).
+ */
+public class WithComparatorSort extends Sort {
+  private final Comparator<Entry<?, ?>> comparator;
+
+  public WithComparatorSort(
+          final List<Order> orders,
+          final Comparator<Entry<?, ?>> comparator) {
+    super(orders);
+    this.comparator = comparator;
+  }
+
+  public Comparator<Entry<?, ?>> getComparator() {
+    return comparator;
+  }
+}


### PR DESCRIPTION
Hook to provide a Comparator for the cache sort and avoid non-optimal the default reflection based value retrieval.
See issue #344.