### PR TITLE
Fix broken Maven central badge in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spring Data Hazelcast
 
 <a href="https://github.com/hazelcast/spring-data-hazelcast/actions?query=event%3Apush+branch%3Amaster"><img alt="GitHub Actions status" src="https://github.com/hazelcast/spring-data-hazelcast/workflows/build/badge.svg"></a>
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/spring-data-hazelcast/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/spring-data-hazelcast) 
+[![Maven Central](https://maven-badges.sml.io/maven-central/com.hazelcast/spring-data-hazelcast/badge.svg)](https://maven-badges.sml.io/maven-central/com.hazelcast/spring-data-hazelcast) 
 
 The primary goal of the [Spring Data](http://projects.spring.io/spring-data/) is to make it easier to build Spring-powered applications that use new data access technologies. This module provides integration with [Hazelcast](http://hazelcast.com).
 


### PR DESCRIPTION
The Maven central badge in `README` does not load; the [URL to the badge has changed](https://github.com/softwaremill/maven-badges#a-new-dns-address).

As such, updated.